### PR TITLE
feat: Add configurable coin loss factor for player deaths

### DIFF
--- a/src/main/java/net/sirgrantd/magic_coins/common/config/CommonConfig.java
+++ b/src/main/java/net/sirgrantd/magic_coins/common/config/CommonConfig.java
@@ -14,10 +14,12 @@ public class CommonConfig {
 
     public static int goldCoinsValue;
     public static int crystalCoinsValue;
+    public static Double coinLossFactor;
 
     public static class Config {
         public static final Supplier<Integer> GOLD_COIN_VALUE;
         public static final Supplier<Integer> CRYSTAL_COIN_VALUE;
+        public static final Supplier<Double> COIN_LOSS_FACTOR;
 
         static {
             ModConfigSpec.Builder CONFIG_BUILDER = new ModConfigSpec.Builder();
@@ -32,6 +34,10 @@ public class CommonConfig {
                 .comment("The value of a crystal coin")
                 .defineInRange("crystalMagicValue", 2500, 0, 25000);
 
+            COIN_LOSS_FACTOR = CONFIG_BUILDER
+                    .comment("How many % coins should be lost on Death?")
+                    .defineInRange("coinLossFactor", 0.5, 0, 1.0);
+
             CONFIG_BUILDER.pop();
 
             SPEC = CONFIG_BUILDER.build();
@@ -43,6 +49,7 @@ public class CommonConfig {
     private static void bakeConfig() {
         goldCoinsValue = Config.GOLD_COIN_VALUE.get();
         crystalCoinsValue = Config.CRYSTAL_COIN_VALUE.get();
+        coinLossFactor = Config.COIN_LOSS_FACTOR.get();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/sirgrantd/magic_coins/common/events/LossCoinsForDeath.java
+++ b/src/main/java/net/sirgrantd/magic_coins/common/events/LossCoinsForDeath.java
@@ -7,6 +7,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.Entity;
+import net.sirgrantd.magic_coins.common.config.CommonConfig;
 
 @EventBusSubscriber
 public class LossCoinsForDeath {
@@ -24,7 +25,7 @@ public class LossCoinsForDeath {
         boolean isCoinsLostOnDeath = BagCoinsManager.getIsCoinsLostOnDeath(player);
 
         if (totalCoins > 0) {
-            double lossFactor = isCoinsLostOnDeath ? 1.0 : 0.5;
+            double lossFactor = isCoinsLostOnDeath ? 1.0 : (1.0 - CommonConfig.coinLossFactor);
 
             int newTotalCoins = (int) Math.round(totalCoins * lossFactor);
             BagCoinsManager.setValueTotalInCoins(player, newTotalCoins);


### PR DESCRIPTION
Introduced a configurable `coinLossFactor` to determine the percentage of coins lost on death. This allows customizing the coin loss behavior through the `CommonConfig` settings. Updated the logic in `LossCoinsForDeath` to incorporate the new configuration value.